### PR TITLE
chore: change lock bot inactivity time from 2 days to 1 day

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,7 +1,7 @@
 # Configuration for Lock Threads - https://github.com/dessant/lock-threads-app
 
 # Number of days of inactivity before a closed issue or pull request is locked
-daysUntilLock: 2
+daysUntilLock: 1
 
 # Skip issues and pull requests created before a given timestamp. Timestamp must
 # follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable


### PR DESCRIPTION
dep bot removal